### PR TITLE
basic for loop gas efficiency improvements

### DIFF
--- a/contracts/CommandBuilder.sol
+++ b/contracts/CommandBuilder.sol
@@ -181,6 +181,6 @@ library CommandBuilder {
 
     function _uncheckedIncrement(uint256 i) private pure returns(uint256) {
     	unchecked {++i;}
-	return i;
+        return i;
     }
 }

--- a/contracts/CommandBuilder.sol
+++ b/contracts/CommandBuilder.sol
@@ -20,7 +20,7 @@ library CommandBuilder {
         uint256 idx;
 
         // Determine the length of the encoded data
-        for (uint256 i; i < 32; ++i) {
+        for (uint256 i; i < 32; i=_uncheckedIncrement(i)) {
             idx = uint8(indices[i]);
             if (idx == IDX_END_OF_ARGS) break;
 
@@ -57,7 +57,7 @@ library CommandBuilder {
             mstore(add(ret, 32), selector)
         }
         count = 0;
-        for (uint256 i; i < 32; ++i) {
+        for (uint256 i; i < 32; i=_uncheckedIncrement(i)) {
             idx = uint8(indices[i]);
             if (idx == IDX_END_OF_ARGS) break;
 
@@ -177,5 +177,10 @@ library CommandBuilder {
                 )
             )
         }
+    }
+
+    function _uncheckedIncrement(uint256 i) private pure returns(uint256) {
+    	unchecked {++i;}
+	return i;
     }
 }

--- a/contracts/CommandBuilder.sol
+++ b/contracts/CommandBuilder.sol
@@ -180,7 +180,7 @@ library CommandBuilder {
     }
 
     function _uncheckedIncrement(uint256 i) private pure returns(uint256) {
-    	unchecked {++i;}
+        unchecked {++i;}
         return i;
     }
 }

--- a/contracts/CommandBuilder.sol
+++ b/contracts/CommandBuilder.sol
@@ -13,14 +13,14 @@ library CommandBuilder {
         bytes4 selector,
         bytes32 indices
     ) internal view returns (bytes memory ret) {
-        uint256 count = 0; // Number of bytes in whole ABI encoded message
-        uint256 free = 0; // Pointer to first free byte in tail part of message
+        uint256 count; // Number of bytes in whole ABI encoded message
+        uint256 free; // Pointer to first free byte in tail part of message
         bytes memory stateData; // Optionally encode the current state if the call requires it
 
         uint256 idx;
 
         // Determine the length of the encoded data
-        for (uint256 i = 0; i < 32; i++) {
+        for (uint256 i; i < 32; ++i) {
             idx = uint8(indices[i]);
             if (idx == IDX_END_OF_ARGS) break;
 
@@ -57,7 +57,7 @@ library CommandBuilder {
             mstore(add(ret, 32), selector)
         }
         count = 0;
-        for (uint256 i = 0; i < 32; i++) {
+        for (uint256 i; i < 32; ++i) {
             idx = uint8(indices[i]);
             if (idx == IDX_END_OF_ARGS) break;
 
@@ -101,7 +101,7 @@ library CommandBuilder {
         bytes[] memory state,
         bytes1 index,
         bytes memory output
-    ) internal view returns (bytes[] memory) {
+    ) internal pure returns (bytes[] memory) {
         uint256 idx = uint8(index);
         if (idx == IDX_END_OF_ARGS) return state;
 

--- a/contracts/Libraries/Math.sol
+++ b/contracts/Libraries/Math.sol
@@ -19,7 +19,7 @@ contract Math {
         pure
         returns (uint256 ret)
     {
-	uint256 valuesLength = values.length;
+        uint256 valuesLength = values.length;
         for (uint256 i; i < valuesLength; ++i) {
             ret += values[i];
         }

--- a/contracts/Libraries/Math.sol
+++ b/contracts/Libraries/Math.sol
@@ -19,7 +19,8 @@ contract Math {
         pure
         returns (uint256 ret)
     {
-        for (uint256 i = 0; i < values.length; i++) {
+	uint256 valuesLength = values.length;
+        for (uint256 i; i < valuesLength; ++i) {
             ret += values[i];
         }
     }

--- a/contracts/VM.sol
+++ b/contracts/VM.sol
@@ -41,7 +41,7 @@ abstract contract VM {
         bytes memory outdata;
 
 	uint256 commandsLength = commands.length;
-        for (uint256 i; i < commandsLength; ++i) {
+        for (uint256 i; i < commandsLength; i=_uncheckedIncrement(i)) {
             command = commands[i];
             flags = uint8(bytes1(command << 32));
 
@@ -118,6 +118,11 @@ abstract contract VM {
             }
         }
         return state;
+    }
+
+    function _uncheckedIncrement(uint256 i) private pure returns(uint256) {
+    	unchecked {++i;}
+	return i;
     }
 }
 

--- a/contracts/VM.sol
+++ b/contracts/VM.sol
@@ -40,7 +40,7 @@ abstract contract VM {
         bool success;
         bytes memory outdata;
 
-	uint256 commandsLength = commands.length;
+        uint256 commandsLength = commands.length;
         for (uint256 i; i < commandsLength; i=_uncheckedIncrement(i)) {
             command = commands[i];
             flags = uint8(bytes1(command << 32));
@@ -122,7 +122,7 @@ abstract contract VM {
 
     function _uncheckedIncrement(uint256 i) private pure returns(uint256) {
     	unchecked {++i;}
-	return i;
+        return i;
     }
 }
 

--- a/contracts/VM.sol
+++ b/contracts/VM.sol
@@ -40,7 +40,8 @@ abstract contract VM {
         bool success;
         bytes memory outdata;
 
-        for (uint256 i = 0; i < commands.length; i++) {
+	uint256 commandsLength = commands.length;
+        for (uint256 i; i < commandsLength; ++i) {
             command = commands[i];
             flags = uint8(bytes1(command << 32));
 

--- a/contracts/VM.sol
+++ b/contracts/VM.sol
@@ -121,7 +121,7 @@ abstract contract VM {
     }
 
     function _uncheckedIncrement(uint256 i) private pure returns(uint256) {
-    	unchecked {++i;}
+        unchecked {++i;}
         return i;
     }
 }

--- a/contracts/test/CommandBuilderHarness.sol
+++ b/contracts/test/CommandBuilderHarness.sol
@@ -18,7 +18,8 @@ contract CommandBuilderHarness {
         bytes[] memory state,
         bytes1 index,
         bytes memory output
-    ) public view returns (bytes[] memory, bytes memory) {
+    ) public pure returns (bytes[] memory, bytes memory) {
+	(index, output); // shh compiler
         return (state, new bytes(32));
     }
 
@@ -36,7 +37,7 @@ contract CommandBuilderHarness {
         bytes[] memory state,
         bytes1 index,
         bytes memory output
-    ) public view returns (bytes[] memory, bytes memory) {
+    ) public pure returns (bytes[] memory, bytes memory) {
         state = state.writeOutputs(index, output);
 
         return (state, output);

--- a/contracts/test/CommandBuilderHarness.sol
+++ b/contracts/test/CommandBuilderHarness.sol
@@ -19,7 +19,7 @@ contract CommandBuilderHarness {
         bytes1 index,
         bytes memory output
     ) public pure returns (bytes[] memory, bytes memory) {
-	(index, output); // shh compiler
+        (index, output); // shh compiler
         return (state, new bytes(32));
     }
 


### PR DESCRIPTION
Low hanging fruit: improving gas efficiency in the "for" loops.

Gas expenditure after
```


  CommandBuilder
buildInputs gas cost: 3402 - argument passing cost: 4843 - total: 29519
    ✓ Should build inputs that match Math.add ABI (107ms)
buildInputs gas cost: 5979 - argument passing cost: 5267 - total: 32520
    ✓ Should build inputs that match Strings.strcat ABI (68ms)
buildInputs gas cost: 3570 - argument passing cost: 4876 - total: 29720
    ✓ Should build inputs that match Math.sum ABI (55ms)
writeOutputs gas cost:  70
    ✓ Should select and overwrite first 32 byte slot in state for output (static test) (42ms)
writeOutputs gas cost:  670
    ✓ Should select and overwrite second dynamic amount bytes in second state slot given a uint[] output (dynamic test) (44ms)
writeOutputs gas cost:  4236
    ✓ Should overwrite entire state with *abi decoded* output value (rawcall) (47ms)

  Tuple
Tuple return+slice: 48463 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (first var)
Tuple return+slice: 48475 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (second var)

  VM
Msg.sender: 38189 gas
    ✓ Should return msg.sender
Array sum: 85753 gas
    ✓ Should execute a simple addition program
String concatenation: 41429 gas
    ✓ Should execute a string length program
String concatenation: 47318 gas
    ✓ Should concatenate two strings
String concatenation: 43054 gas
    ✓ Should sum an array of uints
State passing: 71161 gas
    ✓ Should pass and return raw state to functions
Direct ERC20 transfer: 50276 gas
    ✓ Should perform a ERC20 transfer
    ✓ Should propagate revert reasons


  16 passing (1s)


```

Gas expenditure before
```


  CommandBuilder
buildInputs gas cost: 3718 - argument passing cost: 4843 - total: 29835
    ✓ Should build inputs that match Math.add ABI (107ms)
buildInputs gas cost: 6295 - argument passing cost: 5267 - total: 32836
    ✓ Should build inputs that match Strings.strcat ABI (72ms)
buildInputs gas cost: 3732 - argument passing cost: 4876 - total: 29882
    ✓ Should build inputs that match Math.sum ABI (52ms)
writeOutputs gas cost:  70
    ✓ Should select and overwrite first 32 byte slot in state for output (static test) (45ms)
writeOutputs gas cost:  670
    ✓ Should select and overwrite second dynamic amount bytes in second state slot given a uint[] output (dynamic test) (44ms)
writeOutputs gas cost:  4236
    ✓ Should overwrite entire state with *abi decoded* output value (rawcall) (47ms)

  Tuple
Tuple return+slice: 49191 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (first var)
Tuple return+slice: 49203 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (second var)

  VM
Msg.sender: 38516 gas
    ✓ Should return msg.sender
Array sum: 89195 gas
    ✓ Should execute a simple addition program (40ms)
String concatenation: 41910 gas
    ✓ Should execute a string length program
String concatenation: 47953 gas
    ✓ Should concatenate two strings
String concatenation: 43569 gas
    ✓ Should sum an array of uints
State passing: 72104 gas
    ✓ Should pass and return raw state to functions (44ms)
Direct ERC20 transfer: 50664 gas
    ✓ Should perform a ERC20 transfer (57ms)
    ✓ Should propagate revert reasons


  16 passing (1s)

```
