### PR TITLE
some addition has no chance of overflow.

### DIFF
--- a/contracts/CommandBuilder.sol
+++ b/contracts/CommandBuilder.sol
@@ -30,7 +30,7 @@ library CommandBuilder {
                         stateData = abi.encode(state);
                     }
                     count += stateData.length;
-                    free += 32;
+                    unchecked{free += 32;}
                 } else {
                     // Add the size of the value, rounded up to the next word boundary, plus space for pointer and length
                     uint256 arglen = state[idx & IDX_VALUE_MASK].length;
@@ -39,14 +39,14 @@ library CommandBuilder {
                         "Dynamic state variables must be a multiple of 32 bytes"
                     );
                     count += arglen + 32;
-                    free += 32;
+                    unchecked{free += 32;}
                 }
             } else {
                 require(
                     state[idx & IDX_VALUE_MASK].length == 32,
                     "Static state variables must be 32 bytes"
                 );
-                count += 32;
+                unchecked{count += 32;}
                 free += 32;
             }
         }
@@ -68,7 +68,7 @@ library CommandBuilder {
                     }
                     memcpy(stateData, 32, ret, free + 4, stateData.length - 32);
                     free += stateData.length - 32;
-                    count += 32;
+                    unchecked{count += 32;}
                 } else {
                     uint256 arglen = state[idx & IDX_VALUE_MASK].length;
 
@@ -84,7 +84,7 @@ library CommandBuilder {
                         arglen
                     );
                     free += arglen;
-                    count += 32;
+                    unchecked{count += 32;}
                 }
             } else {
                 // Fixed length data; write it directly
@@ -92,7 +92,7 @@ library CommandBuilder {
                 assembly {
                     mstore(add(add(ret, 36), count), mload(add(statevar, 32)))
                 }
-                count += 32;
+                unchecked{count += 32;}
             }
         }
     }


### PR DESCRIPTION
I found another way to save quite a bit of gas:
Within the `CommandBuilder.sol` there are two instances of variables within a `for` loop bounded by '32' where these variables are incremented by '32' on each loop. Thus their max attainable value is 32*32 = 2^10 < 2^256 -1 and there is no chance of overflow.

The gas expenditure after this optimization:
```


  CommandBuilder
buildInputs gas cost: 2650 - argument passing cost: 4843 - total: 28767
    ✓ Should build inputs that match Math.add ABI (109ms)
buildInputs gas cost: 5227 - argument passing cost: 5267 - total: 31768
    ✓ Should build inputs that match Strings.strcat ABI (66ms)
buildInputs gas cost: 3194 - argument passing cost: 4876 - total: 29344
    ✓ Should build inputs that match Math.sum ABI (50ms)
writeOutputs gas cost:  70
    ✓ Should select and overwrite first 32 byte slot in state for output (static test) (41ms)
writeOutputs gas cost:  670
    ✓ Should select and overwrite second dynamic amount bytes in second state slot given a uint[] output (dynamic test) (44ms)
writeOutputs gas cost:  4236
    ✓ Should overwrite entire state with *abi decoded* output value (rawcall) (49ms)

  Tuple
Tuple return+slice: 47335 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (first var)
Tuple return+slice: 47347 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (second var)

  VM
Msg.sender: 37813 gas
    ✓ Should return msg.sender
Array sum: 79361 gas
    ✓ Should execute a simple addition program
String concatenation: 40677 gas
    ✓ Should execute a string length program
String concatenation: 46190 gas
    ✓ Should concatenate two strings
String concatenation: 42302 gas
    ✓ Should sum an array of uints
State passing: 69281 gas
    ✓ Should pass and return raw state to functions
Direct ERC20 transfer: 49524 gas
    ✓ Should perform a ERC20 transfer
    ✓ Should propagate revert reasons


  16 passing (1s)

```

Gas expenditure before this optimization:
```


  CommandBuilder
buildInputs gas cost: 3402 - argument passing cost: 4843 - total: 29519
    ✓ Should build inputs that match Math.add ABI (118ms)
buildInputs gas cost: 5979 - argument passing cost: 5267 - total: 32520
    ✓ Should build inputs that match Strings.strcat ABI (69ms)
buildInputs gas cost: 3570 - argument passing cost: 4876 - total: 29720
    ✓ Should build inputs that match Math.sum ABI (56ms)
writeOutputs gas cost:  70
    ✓ Should select and overwrite first 32 byte slot in state for output (static test) (41ms)
writeOutputs gas cost:  670
    ✓ Should select and overwrite second dynamic amount bytes in second state slot given a uint[] output (dynamic test) (46ms)
writeOutputs gas cost:  4236
    ✓ Should overwrite entire state with *abi decoded* output value (rawcall) (47ms)

  Tuple
Tuple return+slice: 48463 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (first var)
Tuple return+slice: 48475 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (second var)

  VM
Msg.sender: 38189 gas
    ✓ Should return msg.sender
Array sum: 85753 gas
    ✓ Should execute a simple addition program (39ms)
String concatenation: 41429 gas
    ✓ Should execute a string length program
String concatenation: 47318 gas
    ✓ Should concatenate two strings
String concatenation: 43054 gas
    ✓ Should sum an array of uints
State passing: 71161 gas
    ✓ Should pass and return raw state to functions
Direct ERC20 transfer: 50276 gas
    ✓ Should perform a ERC20 transfer
    ✓ Should propagate revert reasons


  16 passing (1s)


```