### PR TITLE
type change improves gas efficiency

### DIFF
--- a/contracts/VM.sol
+++ b/contracts/VM.sol
@@ -46,7 +46,7 @@ abstract contract VM {
             flags = uint8(bytes1(command << 32));
 
             if (flags & FLAG_EXTENDED_COMMAND != 0) {
-                indices = commands[i++]; // GEORGE does this advance of index "i" make sense?
+                indices = commands[i++];
             } else {
                 indices = bytes32(uint256(command << 40) | SHORT_COMMAND_FILL);
             }

--- a/contracts/VM.sol
+++ b/contracts/VM.sol
@@ -34,7 +34,7 @@ abstract contract VM {
       internal returns (bytes[] memory)
     {
         bytes32 command;
-        uint256 flags;
+        uint8 flags;
         bytes32 indices;
 
         bool success;
@@ -46,7 +46,7 @@ abstract contract VM {
             flags = uint8(bytes1(command << 32));
 
             if (flags & FLAG_EXTENDED_COMMAND != 0) {
-                indices = commands[i++];
+                indices = commands[i++]; // GEORGE does this advance of index "i" make sense?
             } else {
                 indices = bytes32(uint256(command << 40) | SHORT_COMMAND_FILL);
             }


### PR DESCRIPTION
Declaring the `flags` variable within the `VM._execute` function as `uint8` surprisingly improves gas efficiency.
Gas expenditure after this change:
```


  CommandBuilder
buildInputs gas cost: 2650 - argument passing cost: 4843 - total: 28767
    ✓ Should build inputs that match Math.add ABI (104ms)
buildInputs gas cost: 5227 - argument passing cost: 5267 - total: 31768
    ✓ Should build inputs that match Strings.strcat ABI (66ms)
buildInputs gas cost: 3194 - argument passing cost: 4876 - total: 29344
    ✓ Should build inputs that match Math.sum ABI (52ms)
writeOutputs gas cost:  70
    ✓ Should select and overwrite first 32 byte slot in state for output (static test) (58ms)
writeOutputs gas cost:  670
    ✓ Should select and overwrite second dynamic amount bytes in second state slot given a uint[] output (dynamic test) (44ms)
writeOutputs gas cost:  4236
    ✓ Should overwrite entire state with *abi decoded* output value (rawcall) (49ms)

  Tuple
Tuple return+slice: 47317 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (first var)
Tuple return+slice: 47329 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (second var)

  VM
Msg.sender: 37801 gas
    ✓ Should return msg.sender
Array sum: 79307 gas
    ✓ Should execute a simple addition program
String concatenation: 40665 gas
    ✓ Should execute a string length program
String concatenation: 46178 gas
    ✓ Should concatenate two strings
String concatenation: 42290 gas
    ✓ Should sum an array of uints
State passing: 69269 gas
    ✓ Should pass and return raw state to functions
Direct ERC20 transfer: 49518 gas
    ✓ Should perform a ERC20 transfer
    ✓ Should propagate revert reasons


  16 passing (1s)

```
Gas expenditure before this change:

```


  CommandBuilder
buildInputs gas cost: 2650 - argument passing cost: 4843 - total: 28767
    ✓ Should build inputs that match Math.add ABI (115ms)
buildInputs gas cost: 5227 - argument passing cost: 5267 - total: 31768
    ✓ Should build inputs that match Strings.strcat ABI (67ms)
buildInputs gas cost: 3194 - argument passing cost: 4876 - total: 29344
    ✓ Should build inputs that match Math.sum ABI (57ms)
writeOutputs gas cost:  70
    ✓ Should select and overwrite first 32 byte slot in state for output (static test) (44ms)
writeOutputs gas cost:  670
    ✓ Should select and overwrite second dynamic amount bytes in second state slot given a uint[] output (dynamic test) (45ms)
writeOutputs gas cost:  4236
    ✓ Should overwrite entire state with *abi decoded* output value (rawcall) (61ms)

  Tuple
Tuple return+slice: 47335 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (first var)
Tuple return+slice: 47347 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (second var)

  VM
Msg.sender: 37813 gas
    ✓ Should return msg.sender
Array sum: 79361 gas
    ✓ Should execute a simple addition program
String concatenation: 40677 gas
    ✓ Should execute a string length program
String concatenation: 46190 gas
    ✓ Should concatenate two strings
String concatenation: 42302 gas
    ✓ Should sum an array of uints
State passing: 69281 gas
    ✓ Should pass and return raw state to functions
Direct ERC20 transfer: 49524 gas
    ✓ Should perform a ERC20 transfer
    ✓ Should propagate revert reasons


  16 passing (1s)


```