### PR TITLE
gas golfing: update types for more efficient code

### DIFF
--- a/contracts/CommandBuilder.sol
+++ b/contracts/CommandBuilder.sol
@@ -147,7 +147,7 @@ library CommandBuilder {
         bytes1 index,
         bytes memory output
     ) internal view {
-        uint8 idx = uint8(index);
+        uint256 idx = uint256(uint8(index));
         if (idx == IDX_END_OF_ARGS) return;
 
         bytes memory entry = state[idx] = new bytes(output.length + 32);

--- a/contracts/VM.sol
+++ b/contracts/VM.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.11;
 
 import "./CommandBuilder.sol";
 
-uint8 constant FLAG_CT_DELEGATECALL = 0x00;
-uint8 constant FLAG_CT_CALL = 0x01;
-uint8 constant FLAG_CT_STATICCALL = 0x02;
-uint8 constant FLAG_CT_VALUECALL = 0x03;
-uint8 constant FLAG_CT_MASK = 0x03;
-uint8 constant FLAG_EXTENDED_COMMAND = 0x80;
-uint8 constant FLAG_TUPLE_RETURN = 0x40;
+uint256 constant FLAG_CT_DELEGATECALL = 0x00;
+uint256 constant FLAG_CT_CALL = 0x01;
+uint256 constant FLAG_CT_STATICCALL = 0x02;
+uint256 constant FLAG_CT_VALUECALL = 0x03;
+uint256 constant FLAG_CT_MASK = 0x03;
+uint256 constant FLAG_EXTENDED_COMMAND = 0x80;
+uint256 constant FLAG_TUPLE_RETURN = 0x40;
 
 uint256 constant SHORT_COMMAND_FILL = 0x000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 
@@ -34,7 +34,7 @@ abstract contract VM {
       internal returns (bytes[] memory)
     {
         bytes32 command;
-        uint8 flags;
+        uint256 flags;
         bytes32 indices;
 
         bool success;
@@ -43,7 +43,7 @@ abstract contract VM {
         uint256 commandsLength = commands.length;
         for (uint256 i; i < commandsLength; i=_uncheckedIncrement(i)) {
             command = commands[i];
-            flags = uint8(bytes1(command << 32));
+            flags = uint256(uint8(bytes1(command << 32)));
 
             if (flags & FLAG_EXTENDED_COMMAND != 0) {
                 indices = commands[i++];


### PR DESCRIPTION
Another round of improving gas efficiency by choosing more sensible types.
Gas expenditure after this improvement:
```


  CommandBuilder
buildInputs gas cost: 2650 - argument passing cost: 4843 - total: 28767
    ✓ Should build inputs that match Math.add ABI (115ms)
buildInputs gas cost: 5227 - argument passing cost: 5267 - total: 31768
    ✓ Should build inputs that match Strings.strcat ABI (72ms)
buildInputs gas cost: 3194 - argument passing cost: 4876 - total: 29344
    ✓ Should build inputs that match Math.sum ABI (51ms)
writeOutputs gas cost:  70
    ✓ Should select and overwrite first 32 byte slot in state for output (static test) (47ms)
writeOutputs gas cost:  670
    ✓ Should select and overwrite second dynamic amount bytes in second state slot given a uint[] output (dynamic test) (48ms)
writeOutputs gas cost:  4236
    ✓ Should overwrite entire state with *abi decoded* output value (rawcall) (106ms)

  Tuple
Tuple return+slice: 47257 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (first var)
Tuple return+slice: 47269 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (second var)

  VM
Msg.sender: 37765 gas
    ✓ Should return msg.sender
Array sum: 79145 gas
    ✓ Should execute a simple addition program
String concatenation: 40629 gas
    ✓ Should execute a string length program
String concatenation: 46142 gas
    ✓ Should concatenate two strings
String concatenation: 42254 gas
    ✓ Should sum an array of uints
State passing: 69233 gas
    ✓ Should pass and return raw state to functions
Direct ERC20 transfer: 49488 gas
    ✓ Should perform a ERC20 transfer
    ✓ Should propagate revert reasons


  16 passing (1s)

```

Gas expenditure before this improvement:
```


  CommandBuilder
buildInputs gas cost: 2650 - argument passing cost: 4843 - total: 28767
    ✓ Should build inputs that match Math.add ABI (119ms)
buildInputs gas cost: 5227 - argument passing cost: 5267 - total: 31768
    ✓ Should build inputs that match Strings.strcat ABI (68ms)
buildInputs gas cost: 3194 - argument passing cost: 4876 - total: 29344
    ✓ Should build inputs that match Math.sum ABI (58ms)
writeOutputs gas cost:  70
    ✓ Should select and overwrite first 32 byte slot in state for output (static test) (47ms)
writeOutputs gas cost:  670
    ✓ Should select and overwrite second dynamic amount bytes in second state slot given a uint[] output (dynamic test) (48ms)
writeOutputs gas cost:  4236
    ✓ Should overwrite entire state with *abi decoded* output value (rawcall) (50ms)

  Tuple
Tuple return+slice: 47317 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (first var)
Tuple return+slice: 47329 gas
    ✓ Should perform a tuple return that's sliced before being fed to another function (second var)

  VM
Msg.sender: 37801 gas
    ✓ Should return msg.sender
Array sum: 79307 gas
    ✓ Should execute a simple addition program
String concatenation: 40665 gas
    ✓ Should execute a string length program
String concatenation: 46178 gas
    ✓ Should concatenate two strings
String concatenation: 42290 gas
    ✓ Should sum an array of uints
State passing: 69269 gas
    ✓ Should pass and return raw state to functions
Direct ERC20 transfer: 49518 gas
    ✓ Should perform a ERC20 transfer
    ✓ Should propagate revert reasons


  16 passing (1s)

```