### PR TITLE
Fix and add test for call type with value

### DIFF
--- a/contracts/Libraries/Events.sol
+++ b/contracts/Libraries/Events.sol
@@ -27,4 +27,8 @@ contract Events {
     function logUint(uint256 message) external {
         emit LogUint(message);
     }
+
+    function logUintPayable(uint256 message) external payable {
+        emit LogUint(message);
+    }
 }

--- a/contracts/VM.sol
+++ b/contracts/VM.sol
@@ -82,7 +82,7 @@ abstract contract VM {
                 uint256 calleth;
                 bytes memory v = state[uint8(bytes1(indices))];
                 assembly {
-                    mstore(calleth, add(v, 0x20))
+                    calleth := mload(add(v, 0x20))
                 }
                 (success, outdata) = address(uint160(uint256(command))).call{ // target
                     value: calleth

--- a/contracts/test/Payable.sol
+++ b/contracts/test/Payable.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+contract Payable {
+    function pay() external payable {}
+
+    function balance() external view returns (uint256) {
+        return address(this).balance;
+    }
+
+    receive() external payable {}
+
+    fallback() external payable {}
+}

--- a/contracts/test/TestableVM.sol
+++ b/contracts/test/TestableVM.sol
@@ -5,7 +5,10 @@ import "../VM.sol";
 
 contract TestableVM is VM {
     function execute(bytes32[] calldata commands, bytes[] memory state)
-      public returns (bytes[] memory) {
+        public
+        payable
+        returns (bytes[] memory)
+    {
         return _execute(commands, state);
     }
 }


### PR DESCRIPTION
Inspired from https://github.com/weiroll/weiroll/pull/53, this is a PR to `mload` the amount of ETH that will be supplied to a call in the case of a `calltype` equals to `CALL with value`