### PR TITLE
Add full 32 byte commands to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ function add(uint a, uint b) external returns (uint);
 
 `f` should specify this is a delegatecall (`0x00`), `in` needs to specify two input values of fixed length (`var == 0b`). The remaining four input parameters are unneeded and should be set to `0xff`. Supposing the two inputs should come from state elements 0 and 1, the encoded `in` data is thus `0x000001ffffffff`.
 
-`out` needs to specify that the output value is fixed length (`var == 0b`). Supposing the output should be written to state element 2, the encoded `out` data is thus `0x02`.
+`out` needs to specify that the output value is fixed length (`var == 0b`). Supposing the output should be written to state element 2, the encoded `out` data is thus `0x02`. Assuming `address(1)` as `target`, the command is: `0x9f313803000001ffffffff020000000000000000000000000000000000000001`
 
 #### Variable length input and output values
 
@@ -123,7 +123,7 @@ function concatBytes32(bytes32[] inputs) external returns (bytes);
 
 `f` should specify this is a delegatecall (`0x00`), `in` needs to specify one input value of variable length (`var == 1b`), that is an array of 32-byte words (`ws == 1b`). The remaining five input parameters are unneeded and should be set to `0xff`. Supposing the input comes from state element 0, the encoded `in` data is thus `0x00c0ffffffffff`.
 
-`out` needs to specify that the output value is variable length (`var == 1b`). Supposing the output value should be written to state element 1, the encoded `out` data is thus `0x81`.
+`out` needs to specify that the output value is variable length (`var == 1b`). Supposing the output value should be written to state element 1, the encoded `out` data is thus `0x81`. Assuming `address(1)` as `target`, the command is: `0x9e734c6a00c0ffffffffff81000000000000000000000000 0000000000000001`
 
 ## Command execution
 


### PR DESCRIPTION
- These examples can help users of this library to develop tests more safely. And they serve as a check sum for the text that is discussed above.